### PR TITLE
Kube resource pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,7 @@ ENV/
 
 # Spark
 rat-results.txt
+
+# Kubernetes generated templated files
+kube/.generated/
+airflow.tar.gz

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -441,7 +441,6 @@ def task_failed_deps(args):
     Returns the unmet dependencies for a task instance from the perspective of the
     scheduler (i.e. why a task instance doesn't get scheduled and then queued by the
     scheduler, and then run by an executor).
-
     >>> airflow task_failed_deps tutorial sleep 2015-01-01
     Task instance dependencies not met:
     Dagrun Running: Task instance's dagrun did not exist: Unknown reason
@@ -464,7 +463,6 @@ def task_failed_deps(args):
 def task_state(args):
     """
     Returns the state of a TaskInstance at the command line.
-
     >>> airflow task_state tutorial sleep 2015-01-01
     success
     """
@@ -477,7 +475,6 @@ def task_state(args):
 def dag_state(args):
     """
     Returns the state of a DagRun at the command line.
-
     >>> airflow dag_state tutorial 2015-01-01T00:00:00.000000
     running
     """
@@ -566,22 +563,18 @@ def restart_workers(gunicorn_master_proc, num_workers_expected):
     """
     Runs forever, monitoring the child processes of @gunicorn_master_proc and
     restarting workers occasionally.
-
     Each iteration of the loop traverses one edge of this state transition
     diagram, where each state (node) represents
     [ num_ready_workers_running / num_workers_running ]. We expect most time to
     be spent in [n / n]. `bs` is the setting webserver.worker_refresh_batch_size.
-
     The horizontal transition at ? happens after the new worker parses all the
     dags (so it could take a while!)
-
        V ────────────────────────────────────────────────────────────────────────┐
     [n / n] ──TTIN──> [ [n, n+bs) / n + bs ]  ────?───> [n + bs / n + bs] ──TTOU─┘
        ^                          ^───────────────┘
        │
        │      ┌────────────────v
        └──────┴────── [ [0, n) / n ] <─── start
-
     We change the number of workers by sending TTIN and TTOU to the gunicorn
     master process, which increases and decreases the number of child workers
     respectively. Gunicorn guarantees that on TTOU workers are terminated

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -11,101 +11,204 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import calendar
 import logging
 import time
 import os
 import multiprocessing
 from queue import Queue
-from kubernetes import watch
+from datetime import datetime
+from dateutil import parser
+from uuid import uuid4
+from kubernetes import watch, client
+from kubernetes.client.rest import ApiException
 from airflow import settings
 from airflow.contrib.kubernetes.pod_launcher import PodLauncher
 from airflow.executors.base_executor import BaseExecutor
 from airflow.models import TaskInstance
-from airflow.contrib.kubernetes.pod import Pod
 from airflow.utils.state import State
 from airflow import configuration
-from kubernetes import client
+from airflow.exceptions import AirflowConfigException
+from airflow.contrib.kubernetes.pod import Pod
 
 
-def _prep_command_for_container(command):
-    """  
-    When creating a kubernetes pod, the yaml expects the command
-    in the form of ["cmd","arg","arg","arg"...]
-    This function splits the command string into tokens 
-    and then matches it to the convention.
+class KubeConfig:
+    core_section = "core"
+    kubernetes_section = "kubernetes"
 
-    :param command:
+    @staticmethod
+    def safe_get(section, option, default):
+        try:
+            return configuration.get(section, option)
+        except AirflowConfigException:
+            return default
 
-    :return:
+    @staticmethod
+    def safe_getboolean(section, option, default):
+        try:
+            return configuration.getboolean(section, option)
+        except AirflowConfigException:
+            return default
 
-    """
-    return '"' + '","'.join(command.split(' ')[1:]) + '"'
+    def __init__(self):
+        self.dags_folder = configuration.get(self.core_section, 'dags_folder')
+        self.parallelism = configuration.getint(self.core_section, 'PARALLELISM')
+        self.kube_image = configuration.get(self.kubernetes_section, 'container_image')
+        self.delete_worker_pods = self.safe_getboolean(self.kubernetes_section, 'delete_worker_pods', True)
+        self.kube_namespace = os.environ.get('AIRFLOW_KUBE_NAMESPACE', 'default')
+
+        # These two props must be set together
+        self.git_repo = self.safe_get(self.kubernetes_section, 'git_repo', None)
+        self.git_branch = self.safe_get(self.kubernetes_section, 'git_branch', None)
+
+        # Or this one prop
+        self.dags_volume_claim = self.safe_get(self.kubernetes_section, 'dags_volume_claim', None)
+        # And optionally this prop
+        self.dags_volume_subpath = self.safe_get(self.kubernetes_section, 'dags_volume_subpath', None)
+
+        self._validate()
+
+    def _validate(self):
+        if self.dags_volume_claim:
+            # do volume things
+            pass
+        elif self.git_repo and self.git_branch:
+            # do git things
+            pass
+        else:
+            raise AirflowConfigException(
+                "In kubernetes mode you must set the following configs in the `kubernetes` section: "
+                "`dags_volume_claim` or "
+                "`git_repo and git_branch`"
+            )
 
 
-PARALLELISM = configuration.getint('core', 'PARALLELISM')
+class PodMaker:
+    def __init__(self, kube_config):
+        self.logger = logging.getLogger(__name__)
+        self.kube_config = kube_config
+
+    def _get_volumes_and_mounts(self):
+        volume_name = "airflow-dags"
+
+        if self.kube_config.dags_volume_claim:
+            volumes = [{
+                "name": volume_name, "persistentVolumeClaim": {"claimName": self.kube_config.dags_volume_claim}
+            }]
+            volume_mounts = [{
+                "name": volume_name, "mountPath": self.kube_config.dags_folder,
+                "readOnly": True
+            }]
+            if self.kube_config.dags_volume_subpath:
+                volume_mounts[0]["subPath"] = self.kube_config.dags_volume_subpath
+
+            return volumes, volume_mounts
+        else:
+            return [], []
+
+    def _get_args(self, airflow_command):
+        if self.kube_config.dags_volume_claim:
+            self.logger.info("Using k8s_dags_volume_claim for airflow dags")
+            return [airflow_command]
+        else:
+            self.logger.info("Using git-syncher for airflow dags")
+            cmd_args = "mkdir -p {dags_folder} && cd {dags_folder} &&" \
+                       "git init && git remote add origin {git_repo} && git pull origin {git_branch} --depth=1 &&" \
+                       "{command}".format(dags_folder=self.kube_config.dags_folder, git_repo=self.kube_config.git_repo,
+                                          git_branch=self.kube_config.git_branch, command=airflow_command)
+            return [cmd_args]
+
+    def make_pod(self, namespace, pod_id, dag_id, task_id, execution_date, airflow_command):
+        volumes, volume_mounts = self._get_volumes_and_mounts()
+
+        pod = Pod(
+            namespace=namespace,
+            name=pod_id,
+            image=self.kube_config.kube_image,
+            cmds=["bash", "-cx", "--"],
+            args=self._get_args(airflow_command),
+            labels={
+                "airflow-slave": "",
+                "dag_id": dag_id,
+                "task_id": task_id,
+                "execution_date": execution_date
+            },
+            envs={"AIRFLOW__CORE__EXECUTOR": "LocalExecutor"},
+            volumes=volumes,
+            volume_mounts=volume_mounts
+        )
+        return pod
 
 
 class KubernetesJobWatcher(multiprocessing.Process, object):
-    def __init__(self, watch_function, namespace, result_queue, watcher_queue):
+    def __init__(self, namespace, watcher_queue):
         self.logger = logging.getLogger(__name__)
         multiprocessing.Process.__init__(self)
-        self.result_queue = result_queue
-        self._watch_function = watch_function
-        self._watch = watch.Watch()
         self.namespace = namespace
         self.watcher_queue = watcher_queue
+        self._api = client.CoreV1Api()
+        self._watch = watch.Watch()
 
     def run(self):
+        while True:
+            try:
+                self._run()
+            except Exception:
+                self.logger.exception("Unknown error in KubernetesJobWatcher. Failing")
+                raise
+            else:
+                self.logger.warn("Watcher process died gracefully: generator stopped returning values")
+
+    def _run(self):
         self.logger.info("Event: and now my watch begins")
-        for event in self._watch.stream(self._watch_function, self.namespace,
+        for event in self._watch.stream(self._api.list_namespaced_pod, self.namespace,
                                         label_selector='airflow-slave'):
             task = event['object']
             self.logger.info(
                 "Event: {} had an event of type {}".format(task.metadata.name,
                                                            event['type']))
-            self.process_status(task.metadata.name, task.status.phase)
+            self.process_status(task.metadata.name, task.status.phase, task.metadata.labels)
 
-    def process_status(self, job_id, status):
+    def process_status(self, pod_id, status, labels):
         if status == 'Pending':
-            self.logger.info("Event: {} Pending".format(job_id))
+            self.logger.info("Event: {} Pending".format(pod_id))
         elif status == 'Failed':
-            # self.logger.info("Event: {} Failed".format(job_id))
-            self.watcher_queue.put((job_id, State.FAILED))
+            self.logger.info("Event: {} Failed".format(pod_id))
+            self.watcher_queue.put((pod_id, State.FAILED, labels))
         elif status == 'Succeeded':
-            # self.logger.info("Event: {} Succeeded".format(job_id))
-            self.watcher_queue.put((job_id, None))
+            self.logger.info("Event: {} Succeeded".format(pod_id))
+            self.watcher_queue.put((pod_id, None, labels))
         elif status == 'Running':
-            # self.logger.info("Event: {} is Running".format(job_id))
-            self.watcher_queue.put((job_id, State.RUNNING))
+            self.logger.info("Event: {} is Running".format(pod_id))
         else:
-            self.logger.info("Event: Invalid state {} on job {}".format(status, job_id))
+            self.logger.info("Event: Invalid state: {} on pod: {} with labels: {}".format(status, pod_id, labels))
 
 
 class AirflowKubernetesScheduler(object):
-    def __init__(self,
-                 task_queue,
-                 result_queue,
-                 running):
+    def __init__(self, kube_config, task_queue, result_queue):
         self.logger = logging.getLogger(__name__)
         self.logger.info("creating kubernetes executor")
+        self.kube_config = kube_config
         self.task_queue = task_queue
-        self.pending_jobs = set()
-        self.namespace = os.environ['k8s_POD_NAMESPACE']
-        self.logger.info("k8s: using namespace {}".format(self.namespace))
         self.result_queue = result_queue
+        self.namespace = self.kube_config.kube_namespace
+        self.logger.info("k8s: using namespace {}".format(self.namespace))
         self.launcher = PodLauncher()
-        self.current_jobs = {}
-        self.running = running
-        self._task_counter = 0
+        self.pod_maker = PodMaker(kube_config=self.kube_config)
         self.watcher_queue = multiprocessing.Queue()
         self.api = client.CoreV1Api()
+        self.kube_watcher = self._make_kube_watcher()
 
-        watch_function = self.api.read_namespaced_pod
-        w = KubernetesJobWatcher(watch_function, self.namespace,
-                                 self.result_queue, self.watcher_queue)
-        w.start()
+    def _make_kube_watcher(self):
+        watcher = KubernetesJobWatcher(self.namespace, self.watcher_queue)
+        watcher.start()
+        return watcher
+
+    def _health_check_kube_watcher(self):
+        if self.kube_watcher.is_alive():
+            pass
+        else:
+            self.logger.error("Error while health checking kube watcher process. Process died for unknown reasons")
+            self.kube_watcher = self._make_kube_watcher()
 
     def run_next(self, next_job):
         """
@@ -115,147 +218,176 @@ class AirflowKubernetesScheduler(object):
         and store relevent info in the current_jobs map so we can track the job's
         status
 
-        :return: 
+        :return:
 
         """
         self.logger.info('k8s: job is {}'.format(str(next_job)))
-        (key, command) = next_job
-        self.logger.info("running for command {}".format(command))
-        epoch_time = calendar.timegm(time.gmtime())
-        command_list = ["/usr/local/airflow/entrypoint.sh"] + command.split()[1:] + \
-                       ['-km']
-        self._set_host_id(key)
-        pod_id = self._create_job_id_from_key(key=key, epoch_time=epoch_time)
-        self.current_jobs[pod_id] = key
-
-        image = configuration.get('core', 'k8s_image')
-        print("k8s: launching image {}".format(image))
-        pod = Pod(
-            image=image,
-            name=pod_id,
-            labels=["airflow-slave"],
-            cmds=command_list,
-            namespace=self.namespace
+        key, command = next_job
+        dag_id, task_id, execution_date = key
+        self.logger.info("k8s: running for command {}".format(command))
+        self.logger.info("k8s: launching image {}".format(self.kube_config.kube_image))
+        pod = self.pod_maker.make_pod(
+            namespace=self.namespace, pod_id=self._create_pod_id(dag_id, task_id),
+            dag_id=dag_id, task_id=task_id, execution_date=self._datetime_to_label_safe_datestring(execution_date),
+            airflow_command=command
         )
-
         # the watcher will monitor pods, so we do not block.
         self.launcher.run_pod_async(pod)
         self.logger.info("k8s: Job created!")
 
+    def delete_pod(self, pod_id):
+        if self.kube_config.delete_worker_pods:
+            try:
+                self.api.delete_namespaced_pod(pod_id, self.namespace, body=client.V1DeleteOptions())
+            except ApiException as e:
+                if e.status != 404:
+                    raise
+
     def sync(self):
         """
-
         The sync function checks the status of all currently running kubernetes jobs.
-        If a job is completed, it's status is placed in the result queue to 
+        If a job is completed, it's status is placed in the result queue to
         be sent back to the scheduler.
-
         :return:
-
         """
+        self._health_check_kube_watcher()
         while not self.watcher_queue.empty():
             self.process_watcher_task()
 
     def process_watcher_task(self):
-        job_id, state = self.watcher_queue.get()
-        if state == State.RUNNING and job_id in self.pending_jobs:
-            self.pending_jobs.remove(job_id)
-        elif job_id in self.current_jobs:
-            self._complete_job(job_id, state)
-
-    def _complete_job(self, job_id, state):
-        key = self.current_jobs[job_id]
-        self.logger.info("finishing job {}".format(key))
-        self.result_queue.put((key, state))
-        self.current_jobs.pop(job_id)
-        self.running.pop(key)
-
-    def _create_job_id_from_key(self, key, epoch_time):
-        """
-
-        Kubernetes pod names must unique and match specific conventions 
-        (i.e. no spaces, period, etc.)
-        This function creates a unique name using the epoch time and internal counter
-
-        :param key: 
-
-        :param epoch_time: 
-
-        :return:
-
-        """
-
-        keystr = '-'.join([str(x).replace(' ', '-') for x in key[:2]])
-        job_fields = [keystr, str(self._task_counter), str(epoch_time)]
-        unformatted_job_id = '-'.join(job_fields)
-        job_id = unformatted_job_id.replace('_', '-')
-        return job_id
+        pod_id, state, labels = self.watcher_queue.get()
+        logging.info("Attempting to finish pod; pod_id: {}; state: {}; labels: {}".format(pod_id, state, labels))
+        key = self._labels_to_key(labels)
+        if key:
+            self.logger.info("finishing job {}".format(key))
+            self.result_queue.put((key, state, pod_id))
 
     @staticmethod
-    def _set_host_id(key):
-        (dag_id, task_id, ex_time) = key
-        session = settings.Session()
-        item = session.query(TaskInstance) \
-            .filter_by(dag_id=dag_id, task_id=task_id, execution_date=ex_time).one()
-        host_id = item.hostname
-        print("host is {}".format(host_id))
+    def _strip_unsafe_kubernetes_special_chars(string):
+        """
+        Kubernetes only supports lowercase alphanumeric characters and "-" and "." in the pod name
+        However, there are special rules about how "-" and "." can be used so let's only keep alphanumeric chars
+        see here for detail: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+        :param string:
+        :return:
+        """
+        return ''.join(ch.lower() for ind, ch in enumerate(string) if ch.isalnum())
+
+    @staticmethod
+    def _make_safe_pod_id(safe_dag_id, safe_task_id, safe_uuid):
+        """
+        Kubernetes pod names must be <= 253 chars and must pass the following regex for validation
+        "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+        :param safe_dag_id: a dag_id with only alphanumeric characters
+        :param safe_task_id: a task_id with only alphanumeric characters
+        :param random_uuid: a uuid
+        :return:
+        """
+        MAX_POD_ID_LEN = 253
+
+        safe_key = safe_dag_id + safe_task_id
+
+        safe_pod_id = safe_key[:MAX_POD_ID_LEN-len(safe_uuid)-1] + "-" + safe_uuid
+
+        return safe_pod_id
+
+    @staticmethod
+    def _create_pod_id(dag_id, task_id):
+        safe_dag_id = AirflowKubernetesScheduler._strip_unsafe_kubernetes_special_chars(dag_id)
+        safe_task_id = AirflowKubernetesScheduler._strip_unsafe_kubernetes_special_chars(task_id)
+        safe_uuid = AirflowKubernetesScheduler._strip_unsafe_kubernetes_special_chars(uuid4().hex)
+        return AirflowKubernetesScheduler._make_safe_pod_id(safe_dag_id, safe_task_id, safe_uuid)
+
+    @staticmethod
+    def _label_safe_datestring_to_datetime(string):
+        """
+        Kubernetes doesn't like ":" in labels, since ISO datetime format uses ":" but not "_" let's replace ":" with "_"
+        :param string: string
+        :return: datetime.datetime object
+        """
+        return parser.parse(string.replace("_", ":"))
+
+    @staticmethod
+    def _datetime_to_label_safe_datestring(datetime_obj):
+        """
+        Kubernetes doesn't like ":" in labels, since ISO datetime format uses ":" but not "_" let's replace ":" with "_"
+        :param datetime_obj: datetime.datetime object
+        :return: ISO-like string representing the datetime
+        """
+        return datetime_obj.isoformat().replace(":", "_")
+
+    def _labels_to_key(self, labels):
+        try:
+            return labels["dag_id"], labels["task_id"], self._label_safe_datestring_to_datetime(labels["execution_date"])
+        except Exception as e:
+            self.logger.warn("Error while converting labels to key; labels: {}; exception: {}".format(
+                labels, e
+            ))
+            return None
 
 
 class KubernetesExecutor(BaseExecutor):
     def __init__(self):
-        super(KubernetesExecutor, self).__init__(parallelism=PARALLELISM)
+        self.kube_config = KubeConfig()
         self.task_queue = None
         self._session = None
         self.result_queue = None
-        self.pending_tasks = None
         self.kub_client = None
+        super(KubernetesExecutor, self).__init__(parallelism=self.kube_config.parallelism)
+
+    def clear_queued(self):
+        """
+        If the airflow scheduler restarts with pending "Queued" tasks those queued tasks will never be scheduled
+        Thus, on starting up the scheduler let's set all the queued tasks state to None
+        There is a possibility two tasks will be launched like this:
+        one task is launched before scheduler crashes, then the scheduler restarts and its state is set to None,
+        then another task is launched, then both tasks start up
+        however only one of the tasks should be allowed to actually run due to guards in `TI.run` method
+        :return: None
+        """
+        self._session.query(TaskInstance).filter(TaskInstance.state == State.QUEUED).update({
+            TaskInstance.state: State.NONE
+        })
+        self._session.commit()
 
     def start(self):
         self.logger.info('k8s: starting kubernetes executor')
-        self.task_queue = Queue()
         self._session = settings.Session()
+        self.task_queue = Queue()
         self.result_queue = Queue()
-        self.pending_tasks = {}
-        self.kub_client = AirflowKubernetesScheduler(self.task_queue,
-                                                     self.result_queue,
-                                                     running=self.running)
+        self.kub_client = AirflowKubernetesScheduler(self.kube_config, self.task_queue, self.result_queue)
+        self.clear_queued()
+
+    def execute_async(self, key, command, queue=None):
+        self.logger.info("k8s: adding task {} with command {}".format(key, command))
+        self.task_queue.put((key, command))
 
     def sync(self):
         self.kub_client.sync()
         while not self.result_queue.empty():
             results = self.result_queue.get()
             self.logger.info("reporting {}".format(results))
-            self.change_state(*results)
+            self._change_state(*results)
 
-        # TODO this could be a job_counter based on max jobs a user wants
-        if self.job_queue_full() or self.cluster_at_capacity():
-            self.logger.info("currently a job is running")
-        else:
-            self.logger.info("queue ready, running next")
-            if not self.task_queue.empty():
-                (key, command) = self.task_queue.get()
-                self.kub_client.run_next((key, command))
+        if not self.task_queue.empty():
+            key, command = self.task_queue.get()
+            self.kub_client.run_next((key, command))
 
-    def job_queue_full(self):
-        return len(self.kub_client.current_jobs) > PARALLELISM
-
-    def cluster_at_capacity(self):
-        return len(self.pending_tasks) > 5
-
-    def terminate(self):
-        pass
-
-    def change_state(self, key, state):
+    def _change_state(self, key, state, pod_id):
         self.logger.info("k8s: setting state of {} to {}".format(key, state))
         if state != State.RUNNING:
-            # self.kub_client.delete_job(key)
-            self.logger.info("current running {}".format(self.running))
-            self.running.pop(key)
+            self.kub_client.delete_pod(pod_id)
+            try:
+                self.running.pop(key)
+            except KeyError:
+                pass
         self.event_buffer[key] = state
         (dag_id, task_id, ex_time) = key
         item = self._session.query(TaskInstance).filter_by(
             dag_id=dag_id,
             task_id=task_id,
-            execution_date=ex_time).one()
+            execution_date=ex_time
+        ).one()
 
         if item.state == State.RUNNING or item.state == State.QUEUED:
             item.state = state
@@ -266,6 +398,5 @@ class KubernetesExecutor(BaseExecutor):
         self.logger.info('ending kube executor')
         self.task_queue.join()
 
-    def execute_async(self, key, command, queue=None):
-        self.logger.info("k8s: adding task {} with command {}".format(key, command))
-        self.task_queue.put((key, command))
+    def terminate(self):
+        pass

--- a/airflow/contrib/kubernetes/__init__.py
+++ b/airflow/contrib/kubernetes/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/airflow/contrib/kubernetes/kube_client.py
+++ b/airflow/contrib/kubernetes/kube_client.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def get_kube_client(in_cluster=True):
+    # TODO: This should also allow people to point to a cluster.
+
+    from kubernetes import config, client
+
+    if in_cluster:
+        config.load_incluster_config()
+        return client.CoreV1Api()
+    else:
+        NotImplementedError("Running kubernetes jobs from not within the cluster is not supported at this time")

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -30,9 +30,6 @@ spec:
     - name: base
       image: airflow-slave:latest
       command: ["/usr/local/airflow/entrypoint.sh", "/bin/bash sleep 25"]
-      volumeMounts:
-        - name: shared-data
-          mountPath: "/usr/local/airflow/dags"
   restartPolicy: Never
     """
 
@@ -45,10 +42,12 @@ spec:
         self.extract_name(pod, req)
         self.extract_labels(pod, req)
         self.extract_image(pod, req)
+        self.extract_image_pull_policy(pod, req)
         self.extract_cmds(pod, req)
-        if len(pod.node_selectors) > 0:
-            self.extract_node_selector(pod, req)
+        self.extract_args(pod, req)
+        self.extract_node_selector(pod, req)
         self.extract_secrets(pod, req)
         self.extract_volume_secrets(pod, req)
-        self.attach_volume_mounts(req=req, pod=pod)
+        self.attach_volumes(pod, req)
+        self.attach_volume_mounts(pod, req)
         return req

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -14,6 +14,7 @@
 
 import logging
 
+
 class Pod:
     """
         Represents a kubernetes pod and manages execution of a single pod.
@@ -28,7 +29,6 @@ class Pod:
         :param result: The result that will be returned to the operator after
                        successful execution of the pod
         :type result: any
-
     """
     pod_timeout = 3600
 
@@ -37,22 +37,27 @@ class Pod:
             image,
             envs,
             cmds,
-            secrets,
+            args=None,
+            secrets=None,
             labels=None,
             node_selectors=None,
             name=None,
-            volumes = [],
+            volumes=None,
+            volume_mounts=None,
             namespace='default',
-            result=None):
+            result=None,
+            image_pull_policy="IfNotPresent"):
         self.image = image
-        self.envs = envs if envs else {}
+        self.envs = envs or {}
         self.cmds = cmds
-        self.secrets = secrets
+        self.args = args or []
+        self.secrets = secrets or []
         self.result = result
-        self.labels = labels if labels else []
+        self.labels = labels or {}
         self.name = name
-        self.volumes = volumes
-        self.node_selectors = node_selectors if node_selectors else []
+        self.volumes = volumes or []
+        self.volume_mounts = volume_mounts or []
+        self.node_selectors = node_selectors or []
         self.namespace = namespace
+        self.image_pull_policy = image_pull_policy
         self.logger = logging.getLogger(self.__class__.__name__)
-

--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -13,17 +13,19 @@
 # limitations under the License.
 from airflow.contrib.kubernetes.pod import Pod
 from airflow.contrib.kubernetes.kubernetes_request_factory import SimplePodRequestFactory
-from kubernetes import config, client, watch
+from kubernetes import watch
 from kubernetes.client import V1Pod
 from airflow.utils.state import State
 import json
 import logging
 
+from .kube_client import get_kube_client
+
 
 class PodLauncher:
-    def __init__(self):
+    def __init__(self, kube_client=None):
         self.kube_req_factory = SimplePodRequestFactory()
-        self._client = self._kube_client()
+        self._client = kube_client or get_kube_client()
         self._watch = watch.Watch()
         self.logger = logging.getLogger(__name__)
 
@@ -41,11 +43,6 @@ class PodLauncher:
         resp = self.run_pod_async(pod)
         final_status = self._monitor_pod(pod)
         return final_status
-
-    def _kube_client(self):
-        #TODO: This should also allow people to point to a cluster.
-        config.load_incluster_config()
-        return client.CoreV1Api()
 
     def _monitor_pod(self, pod):
         # type: (Pod) -> State

--- a/airflow/executors/__init__.py
+++ b/airflow/executors/__init__.py
@@ -16,11 +16,10 @@ import logging
 import sys
 
 from airflow import configuration
+from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
-
-from airflow.exceptions import AirflowException
 
 DEFAULT_EXECUTOR = None
 
@@ -47,6 +46,8 @@ def GetDefaultExecutor():
     return DEFAULT_EXECUTOR
 
 
+
+
 def _get_executor(executor_name):
     """
     Creates a new instance of the named executor. In case the executor name is not know in airflow, 
@@ -65,6 +66,9 @@ def _get_executor(executor_name):
     elif executor_name == 'MesosExecutor':
         from airflow.contrib.executors.mesos_executor import MesosExecutor
         return MesosExecutor()
+    elif executor_name == 'KubernetesExecutor':
+        from airflow.contrib.executors.kubernetes_executor import KubernetesExecutor
+        return KubernetesExecutor()
     else:
         # Loading plugins
         _integrate_plugins()

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -17,7 +17,6 @@ from builtins import range
 from airflow import configuration
 from airflow.utils.state import State
 from airflow.utils.logging import LoggingMixin
-
 PARALLELISM = configuration.getint('core', 'PARALLELISM')
 
 
@@ -49,6 +48,8 @@ class BaseExecutor(LoggingMixin):
         if key not in self.queued_tasks and key not in self.running:
             self.logger.info("Adding to queue: {}".format(command))
             self.queued_tasks[key] = (command, priority, queue, task_instance)
+        else:
+            self.logger.info("could not queue task {}".format(key))
 
     def queue_task_instance(
             self,
@@ -93,7 +94,6 @@ class BaseExecutor(LoggingMixin):
         pass
 
     def heartbeat(self):
-
         # Triggering new jobs
         if not self.parallelism:
             open_slots = len(self.queued_tasks)
@@ -123,7 +123,7 @@ class BaseExecutor(LoggingMixin):
                 self.running[key] = command
                 self.execute_async(key, command=command, queue=queue)
             else:
-                self.logger.debug(
+                self.logger.info(
                     'Task is already running, not sending to '
                     'executor: {}'.format(key))
 

--- a/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
+++ b/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
@@ -1,0 +1,50 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""kubernetes_resource_checkpointing
+
+Revision ID: 33ae817a1ff4
+Revises: 947454bf1dff
+Create Date: 2017-09-11 15:26:47.598494
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '33ae817a1ff4'
+down_revision = '947454bf1dff'
+branch_labels = None
+depends_on = None
+
+
+from alembic import op
+import sqlalchemy as sa
+
+
+RESOURCE_TABLE = "kube_resource_version"
+
+
+def upgrade():
+    table = op.create_table(
+        RESOURCE_TABLE,
+        sa.Column("one_row_id", sa.Boolean, server_default=sa.true(), primary_key=True),
+        sa.Column("resource_version", sa.String(255)),
+        sa.CheckConstraint("one_row_id", name="kube_resource_version_one_row_id")
+    )
+    op.bulk_insert(table, [
+        {"resource_version": ""}
+    ])
+
+
+def downgrade():
+    op.drop_table(RESOURCE_TABLE)
+

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -51,7 +51,7 @@ from urllib.parse import urlparse
 from sqlalchemy import (
     Column, Integer, String, DateTime, Text, Boolean, ForeignKey, PickleType,
     Index, Float, LargeBinary)
-from sqlalchemy import func, or_, and_
+from sqlalchemy import func, or_, and_, true as sqltrue
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.dialects.mysql import LONGTEXT
 from sqlalchemy.orm import reconstructor, relationship, synonym
@@ -4661,3 +4661,24 @@ class ImportError(Base):
     timestamp = Column(DateTime)
     filename = Column(String(1024))
     stacktrace = Column(Text)
+
+
+class KubeResourceVersion(Base):
+    __tablename__ = "kube_resource_version"
+    one_row_id = Column(Boolean, server_default=sqltrue(), primary_key=True)
+    resource_version = Column(String(255))
+
+    @staticmethod
+    @provide_session
+    def get_current_resource_version(session=None):
+        (resource_version,) = session.query(KubeResourceVersion.resource_version).one()
+        return resource_version
+
+    @staticmethod
+    @provide_session
+    def checkpoint_resource_version(resource_version, session=None):
+        if resource_version:
+            session.query(KubeResourceVersion).update({
+                KubeResourceVersion.resource_version: resource_version
+            })
+            session.commit()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:16.04
+
+# install deps
+RUN apt-get update -y && apt-get install -y \
+        wget \
+        python-dev \
+        python-pip \
+        libczmq-dev \
+        libcurlpp-dev \
+        curl \
+        libssl-dev \
+        git \
+        inetutils-telnet \
+        bind9utils
+
+RUN pip install -U setuptools && \
+    pip install -U pip
+
+RUN pip install kubernetes && \
+    pip install cryptography && \
+    pip install psycopg2==2.7.1
+
+# install airflow
+COPY airflow.tar.gz /tmp/airflow.tar.gz
+RUN pip install /tmp/airflow.tar.gz
+
+# prep airflow
+ENV AIRFLOW_HOME=/root/airflow
+ENV AIRFLOW__CORE__EXECUTOR=KubernetesExecutor
+ENV AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgresql+psycopg2://root:root@postgres-airflow:5432/airflow
+
+
+COPY bootstrap.sh /bootstrap.sh
+RUN chmod +x /bootstrap.sh
+
+ENTRYPOINT ["/bootstrap.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install -U setuptools && \
 
 RUN pip install kubernetes && \
     pip install cryptography && \
-    pip install psycopg2==2.7.1
+    pip install psycopg2==2.7.3.1  # I had issues with older versions of psycopg2, just a warning
 
 # install airflow
 COPY airflow.tar.gz /tmp/airflow.tar.gz

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# launch the appropriate process
+
+if [ "$1" = "webserver" ]
+then
+	exec airflow webserver
+fi
+
+if [ "$1" = "scheduler" ]
+then
+	exec airflow scheduler
+fi

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,12 @@
+IMAGE=grantnicholas/kubeairflow
+TAG=${1:-latest}
+
+if [ -f airflow.tar.gz ]; then
+    echo "Not rebuilding airflow source"
+else
+    cd ../ && python setup.py sdist && cd docker && \
+    cp ../dist/apache-airflow-1.9.0.dev0+incubating.tar.gz airflow.tar.gz
+fi
+
+docker build . --tag=${IMAGE}:${TAG}
+docker push ${IMAGE}:${TAG}

--- a/kube/airflow.yaml.template
+++ b/kube/airflow.yaml.template
@@ -1,0 +1,145 @@
+# The backing volume can be anything you want, it just needs to be `ReadWriteOnce`
+# I'm using hostPath since minikube is nice for testing, but any (non-local) volume will work on a real cluster
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: airflow-dags
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/data/airflow-dags"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: airflow-dags
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: airflow
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: airflow
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+              "name": "init",
+              "image": "{{docker_image}}",
+              "command": [
+                "bash", "-cx", "rm -rf $AIRFLOW_HOME/dags/* && rm -rf $AIRFLOW_HOME/dags/.git && cd $AIRFLOW_HOME/dags && git init && git remote add origin https://github.com/grantnicholas/testdags.git && git pull origin master && cd /usr/local/lib/python2.7/dist-packages/airflow && airflow initdb && alembic upgrade head"
+              ],
+              "env": [
+                {"name": "AIRFLOW__KUBERNETES__CONTAINER_IMAGE", "value": ""},
+                {"name": "AIRFLOW__KUBERNETES__DAGS_VOLUME_CLAIM", "value": "airflow-dags"},
+                {"name": "AIRFLOW__KUBERNETES__DAGS_VOLUME_SUBPATH", "value": "git"}
+              ],
+              "volumeMounts": [
+                {"name": "airflow-dags", "mountPath": "/root/airflow/dags"}
+              ]
+          }
+      ]'
+    spec:
+      containers:
+      - name: web
+        image: {{docker_image}}
+        ports:
+        - name: web
+          containerPort: 8080
+        args: ["webserver"]
+        env:
+        - name: AIRFLOW_KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AIRFLOW__CORE__EXECUTOR
+          value: KubernetesExecutor
+        - name: AIRFLOW__KUBERNETES__CONTAINER_IMAGE
+          value: {{docker_image}}
+        - name: AIRFLOW__KUBERNETES__DELETE_WORKER_PODS
+          value: "True"
+        # set these two confs
+        - name: AIRFLOW__KUBERNETES__GIT_REPO
+          value: https://github.com/grantnicholas/testdags.git
+        - name: AIRFLOW__KUBERNETES__GIT_BRANCH
+          value: master
+        # or this one
+        - name: AIRFLOW__KUBERNETES__DAGS_VOLUME_CLAIM
+          value: airflow-dags
+        #
+        volumeMounts:
+        - name: airflow-dags
+          mountPath: /root/airflow/dags
+        readinessProbe:
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+          periodSeconds: 5
+          httpGet:
+            path: /admin
+            port: 8080
+        livenessProbe:
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 5
+          httpGet:
+            path: /admin
+            port: 8080
+      - name: scheduler
+        image: {{docker_image}}
+        args: ["scheduler"]
+        env:
+        - name: AIRFLOW_KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AIRFLOW__CORE__EXECUTOR
+          value: KubernetesExecutor
+        - name: AIRFLOW__KUBERNETES__CONTAINER_IMAGE
+          value: {{docker_image}}
+        - name: AIRFLOW__KUBERNETES__DELETE_WORKER_PODS
+          value: "True"
+        # set these two confs
+        - name: AIRFLOW__KUBERNETES__GIT_REPO
+          value: https://github.com/grantnicholas/testdags.git
+        - name: AIRFLOW__KUBERNETES__GIT_BRANCH
+          value: master
+        # or set this one
+        - name: AIRFLOW__KUBERNETES__DAGS_VOLUME_CLAIM
+          value: airflow-dags
+        #
+        - name: AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL
+          value: "60"
+        volumeMounts:
+        - name: airflow-dags
+          mountPath: /root/airflow/dags
+      volumes:
+      - name: airflow-dags
+        persistentVolumeClaim:
+          claimName: airflow-dags
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      nodePort: 30809
+  selector:
+    name: airflow
+

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -1,0 +1,6 @@
+IMAGE=${1:-grantnicholas/kubeairflow}
+TAG=${2:-latest}
+
+mkdir -p .generated
+kubectl apply -f postgres.yaml
+sed "s#{{docker_image}}#$IMAGE:$TAG#g" airflow.yaml.template > .generated/airflow.yaml && kubectl apply -f .generated/airflow.yaml

--- a/kube/postgres.yaml
+++ b/kube/postgres.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres-airflow
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 5Gi
+  hostPath:
+    path: /data/postgres-airflow
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: postgres-airflow
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: postgres-airflow
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: postgres-airflow
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: postgres
+          image: postgres
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: dbvol
+              mountPath: /var/lib/postgresql/data/pgdata
+              subPath: pgdata
+          env:
+            - name: POSTGRES_USER
+              value: root
+            - name: POSTGRES_PASSWORD
+              value: root
+            - name: POSTGRES_DB
+              value: airflow
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POD_IP
+              valueFrom: { fieldRef: { fieldPath: status.podIP } }
+          livenessProbe:
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 5
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - exec pg_isready --host $POD_IP ||  if [[ $(psql -qtAc --host $POD_IP 'SELECT pg_is_in_recovery') != "f" ]]; then  exit 0 else; exit 1; fi
+          readinessProbe:
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 5
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - exec pg_isready --host $POD_IP
+          resources:
+            requests:
+              memory: .5Gi
+              cpu: .5
+      volumes:
+        - name: dbvol
+          persistentVolumeClaim:
+            claimName: postgres-airflow
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-airflow
+spec:
+  clusterIP: None
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    name: postgres-airflow

--- a/scripts/ci/requirements.txt
+++ b/scripts/ci/requirements.txt
@@ -91,3 +91,4 @@ thrift
 thrift_sasl
 unicodecsv
 zdesk
+kubernetes

--- a/tests/contrib/executors/kubernetes_executor.py
+++ b/tests/contrib/executors/kubernetes_executor.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import re
+import string
+import random
+from datetime import datetime
+
+try:
+    from airflow.contrib.executors.kubernetes_executor import AirflowKubernetesScheduler
+except ImportError:
+    AirflowKubernetesScheduler = None
+
+
+class TestAirflowKubernetesScheduler(unittest.TestCase):
+
+    def _gen_random_string(self, str_len):
+        return ''.join([random.choice(string.printable) for _ in xrange(str_len)])
+
+    def _cases(self):
+        cases = [
+            ("my_dag_id", "my-task-id"),
+            ("my.dag.id", "my.task.id"),
+            ("MYDAGID", "MYTASKID"),
+            ("my_dag_id", "my_task_id"),
+            ("mydagid"*200, "my_task_id"*200)
+        ]
+
+        cases.extend([
+            (self._gen_random_string(200), self._gen_random_string(200))
+            for _ in xrange(100)
+        ])
+
+        return cases
+
+    def _is_valid_name(self, name):
+        regex = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+        return len(name) <= 253 and \
+               all(ch.lower() == ch for ch in name) and \
+               re.match(regex, name)
+
+    @unittest.skipIf(AirflowKubernetesScheduler is None, 'kubernetes python package is not installed')
+    def test_create_pod_id(self):
+        for dag_id, task_id in self._cases():
+            pod_name = AirflowKubernetesScheduler._create_pod_id(dag_id, task_id)
+            assert self._is_valid_name(pod_name)
+
+    @unittest.skipIf(AirflowKubernetesScheduler is None, "kubernetes python package is not installed")
+    def test_execution_date_serialize_deserialize(self):
+        datetime_obj = datetime.now()
+        serialized_datetime = AirflowKubernetesScheduler._datetime_to_label_safe_datestring(datetime_obj)
+        new_datetime_obj = AirflowKubernetesScheduler._label_safe_datestring_to_datetime(serialized_datetime)
+
+        assert datetime_obj == new_datetime_obj
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
After [the other PR](https://github.com/bloomberg/airflow/pull/6) is merged, this is the next PR that deals with crash safety of the scheduler. We do this by periodically persisting the `resourceVersion` of the watch into the airflow metadata database. When the scheduler starts up it then uses that `resourceVersion` from the metadata database to start watching. 

[Here's the diff ](https://github.com/grantnicholas/incubator-airflow/compare/k8s-executor-2...grantnicholas:kube_resource_pinning)if people are curious before the other PR gets merged. 