### PR TITLE
Fixed alembic head, was pointing to two tips

### DIFF
--- a/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
+++ b/airflow/migrations/versions/33ae817a1ff4_add_kubernetes_resource_checkpointing.py
@@ -21,7 +21,7 @@ Create Date: 2017-09-11 15:26:47.598494
 
 # revision identifiers, used by Alembic.
 revision = '33ae817a1ff4'
-down_revision = '947454bf1dff'
+down_revision = 'd2ae31099d61'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Someone on airflow master added a new revision to alembic and when we did the backmerge there were now two "heads" to alembic. This is just making it so that our alembic revision is applied after the ones on airflow master. Tests on Travis should pass now.