### PR TITLE
Small cleanup to address PR comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
       env: TOX_ENV=py34-hdp-airflow_backend_sqlite
     - python: "2.7"
       env: TOX_ENV=py34-hdp-airflow_backend_postgres
-    - python: "3.4"
+    - python: "2.7"
       env: TOX_ENV=py27-cdh-airflow_backend_postgres RUN_KUBE_INTEGRATION=true
   allow_failures:
     - env: TOX_ENV=py27-cdh-airflow_backend_postgres RUN_KUBE_INTEGRATION=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,8 @@ matrix:
       env: TOX_ENV=py34-hdp-airflow_backend_sqlite
     - python: "2.7"
       env: TOX_ENV=py34-hdp-airflow_backend_postgres
-    - python: "2.7"
-      env: TOX_ENV=py27-cdh-airflow_backend_postgres RUN_KUBE_INTEGRATION=true
+    - python: "3.4"
+      env: TOX_ENV=py34-cdh-airflow_backend_postgres RUN_KUBE_INTEGRATION=true
   allow_failures:
     - env: TOX_ENV=py27-cdh-airflow_backend_postgres RUN_KUBE_INTEGRATION=true
 cache:

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -62,7 +62,8 @@ class KubeConfig:
             self.kubernetes_section, 'worker_container_tag')
         self.kube_image = '{}:{}'.format(
             self.worker_container_repository, self.worker_container_tag)
-        self.delete_worker_pods = self.safe_getboolean(self.kubernetes_section, 'delete_worker_pods', True)
+        self.delete_worker_pods = self.safe_getboolean(
+            self.kubernetes_section, 'delete_worker_pods', True)
 
         self.worker_service_account_name = self.safe_get(
             self.kubernetes_section, 'worker_service_account_name', 'default')
@@ -85,7 +86,8 @@ class KubeConfig:
         self.dags_volume_claim = self.safe_get(self.kubernetes_section, 'dags_volume_claim', None)
 
         # This prop may optionally be set for PV Claims and is used to locate DAGs on a SubPath
-        self.dags_volume_subpath = self.safe_get(self.kubernetes_section, 'dags_volume_subpath', None)
+        self.dags_volume_subpath = self.safe_get(
+            self.kubernetes_section, 'dags_volume_subpath', None)
 
         # The Kubernetes Namespace in which the Scheduler and Webserver reside. Note that if your
         # cluster has RBAC enabled, your scheduler may need service account permissions to
@@ -96,7 +98,8 @@ class KubeConfig:
         # interact with cluster components.
         self.executor_namespace = self.safe_get(self.kubernetes_section, 'namespace', 'default')
         # Task secrets managed by KubernetesExecutor.
-        self.gcp_service_account_keys = self.safe_get(self.kubernetes_section, 'gcp_service_account_keys', None)
+        self.gcp_service_account_keys = self.safe_get(
+            self.kubernetes_section, 'gcp_service_account_keys', None)
 
         # If the user is using the git-sync container to clone their repository via git,
         # allow them to specify repository, tag, and pod name for the init container.
@@ -120,10 +123,8 @@ class KubeConfig:
     def _validate(self):
         if not self.dags_volume_claim and (not self.git_repo or not self.git_branch):
             raise AirflowConfigException(
-                "In kubernetes mode you must set the following configs in the `kubernetes` section: "
-                "`dags_volume_claim` or "
-                "`git_repo and git_branch` "
-            )
+                "In kubernetes mode the following must be set in the `kubernetes` config section: "
+                "`dags_volume_claim` or `git_repo and git_branch` ")
 
 
 class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
@@ -146,7 +147,9 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
                               "last resource_version: {}".format(self.resource_version))
 
     def _run(self, kube_client, resource_version):
-        self.log.info("Event: and now my watch begins starting at resource_version: {}".format(resource_version))
+        self.log.info(
+            "Event: and now my watch begins starting at resource_version: {}"
+            .format(resource_version))
         watcher = watch.Watch()
 
         kwargs = {"label_selector": "airflow-slave"}
@@ -156,9 +159,11 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
         last_resource_version = None
         for event in watcher.stream(kube_client.list_namespaced_pod, self.namespace, **kwargs):
             task = event['object']
-            self.log.info("Event: {} had an event of type {}".format(task.metadata.name, event['type']))
+            self.log.info(
+                "Event: {} had an event of type {}".format(task.metadata.name, event['type']))
             self.process_status(
-                task.metadata.name, task.status.phase, task.metadata.labels, task.metadata.resource_version
+                task.metadata.name, task.status.phase, task.metadata.labels,
+                task.metadata.resource_version
             )
             last_resource_version = task.metadata.resource_version
 
@@ -177,7 +182,8 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin, object):
             self.log.info("Event: {} is Running".format(pod_id))
         else:
             self.log.warn("Event: Invalid state: {} on pod: {} with labels: {} "
-                             "with resource_version: {}".format(status, pod_id, labels, resource_version))
+                          "with resource_version: {}"
+                          .format(status, pod_id, labels, resource_version))
 
 
 class AirflowKubernetesScheduler(LoggingMixin, object):
@@ -205,7 +211,9 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
         if self.kube_watcher.is_alive():
             pass
         else:
-            self.log.error("Error while health checking kube watcher process. Process died for unknown reasons")
+            self.log.error(
+                "Error while health checking kube watcher process. "
+                "Process died for unknown reasons")
             self.kube_watcher = self._make_kube_watcher()
 
     def run_next(self, next_job):
@@ -214,7 +222,6 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
         It will then create a unique job-id, launch that job in the cluster,
         and store relevent info in the current_jobs map so we can track the job's
         status
-        :return:
         """
         self.log.debug('k8s: job is {}'.format(str(next_job)))
         key, command = next_job
@@ -223,7 +230,8 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
         self.log.debug("k8s: launching image {}".format(self.kube_config.kube_image))
         pod = self.worker_configuration.make_pod(
             namespace=self.namespace, pod_id=self._create_pod_id(dag_id, task_id),
-            dag_id=dag_id, task_id=task_id, execution_date=self._datetime_to_label_safe_datestring(execution_date),
+            dag_id=dag_id, task_id=task_id,
+            execution_date=self._datetime_to_label_safe_datestring(execution_date),
             airflow_command=command
         )
         # the watcher will monitor pods, so we do not block.
@@ -233,7 +241,8 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
     def delete_pod(self, pod_id):
         if self.kube_config.delete_worker_pods:
             try:
-                self.kube_client.delete_namespaced_pod(pod_id, self.namespace, body=client.V1DeleteOptions())
+                self.kube_client.delete_namespaced_pod(
+                    pod_id, self.namespace, body=client.V1DeleteOptions())
             except ApiException as e:
                 if e.status != 404:
                     raise
@@ -251,7 +260,9 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
 
     def process_watcher_task(self):
         pod_id, state, labels, resource_version = self.watcher_queue.get()
-        self.log.info("Attempting to finish pod; pod_id: {}; state: {}; labels: {}".format(pod_id, state, labels))
+        self.log.info(
+            "Attempting to finish pod; pod_id: {}; state: {}; labels: {}"
+            .format(pod_id, state, labels))
         key = self._labels_to_key(labels)
         if key:
             self.log.debug("finishing job {} - {} ({})".format(key, state, pod_id))
@@ -261,10 +272,12 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
     def _strip_unsafe_kubernetes_special_chars(string):
         """
         Kubernetes only supports lowercase alphanumeric characters and "-" and "." in the pod name
-        However, there are special rules about how "-" and "." can be used so let's only keep alphanumeric chars
-        see here for detail: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-        :param string:
-        :return:
+        However, there are special rules about how "-" and "." can be used so let's only keep
+        alphanumeric chars  see here for detail:
+        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+
+        :param string: The requested Pod name
+        :return: ``str`` Pod name stripped of any unsafe characters
         """
         return ''.join(ch.lower() for ind, ch in enumerate(string) if ch.isalnum())
 
@@ -273,10 +286,11 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
         """
         Kubernetes pod names must be <= 253 chars and must pass the following regex for validation
         "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+
         :param safe_dag_id: a dag_id with only alphanumeric characters
         :param safe_task_id: a task_id with only alphanumeric characters
         :param random_uuid: a uuid
-        :return:
+        :return: ``str`` valid Pod name of appropriate length
         """
         MAX_POD_ID_LEN = 253
 
@@ -296,7 +310,9 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
     @staticmethod
     def _label_safe_datestring_to_datetime(string):
         """
-        Kubernetes doesn't like ":" in labels, since ISO datetime format uses ":" but not "_" let's replace ":" with "_"
+        Kubernetes doesn't permit ":" in labels. ISO datetime format uses ":" but not "_", let's
+        replace ":" with "_"
+
         :param string: string
         :return: datetime.datetime object
         """
@@ -305,7 +321,8 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
     @staticmethod
     def _datetime_to_label_safe_datestring(datetime_obj):
         """
-        Kubernetes doesn't like ":" in labels, since ISO datetime format uses ":" but not "_" let's replace ":" with "_"
+        Kubernetes doesn't like ":" in labels, since ISO datetime format uses ":" but not "_" let's
+        replace ":" with "_"
         :param datetime_obj: datetime.datetime object
         :return: ISO-like string representing the datetime
         """
@@ -313,7 +330,9 @@ class AirflowKubernetesScheduler(LoggingMixin, object):
 
     def _labels_to_key(self, labels):
         try:
-            return labels["dag_id"], labels["task_id"], self._label_safe_datestring_to_datetime(labels["execution_date"])
+            return (
+                labels["dag_id"], labels["task_id"],
+                self._label_safe_datestring_to_datetime(labels["execution_date"]))
         except Exception as e:
             self.log.warn("Error while converting labels to key; labels: {}; exception: {}".format(
                 labels, e
@@ -333,23 +352,32 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
 
     def clear_not_launched_queued_tasks(self):
         """
-        If the airflow scheduler restarts with pending "Queued" tasks, the tasks may or may not have been launched
-        Thus, on starting up the scheduler let's check every "Queued" task to see if it has been launched
-            (ie: if there is a corresponding pod on kubernetes)
-        If it has been launched then do nothing, otherwise reset the state to "None" so the task will be rescheduled
-        This will not be necessary in a future version of airflow in which there is proper support for State.LAUNCHED
-        :return: None
+        If the airflow scheduler restarts with pending "Queued" tasks, the tasks may or may not
+        have been launched Thus, on starting up the scheduler let's check every "Queued" task to
+        see if it has been launched (ie: if there is a corresponding pod on kubernetes)
+
+        If it has been launched then do nothing, otherwise reset the state to "None" so the task
+        will be rescheduled
+
+        This will not be necessary in a future version of airflow in which there is proper support
+        for State.LAUNCHED
         """
-        queued_tasks = self._session.query(TaskInstance).filter(TaskInstance.state == State.QUEUED).all()
-        self.log.info("When executor started up, found {} queued task instances".format(len(queued_tasks)))
+        queued_tasks = self._session.query(
+            TaskInstance).filter(TaskInstance.state == State.QUEUED).all()
+        self.log.info(
+            "When executor started up, found {} queued task instances".format(len(queued_tasks)))
 
         for t in queued_tasks:
             kwargs = dict(label_selector="dag_id={},task_id={},execution_date={}".format(
-                t.dag_id, t.task_id, AirflowKubernetesScheduler._datetime_to_label_safe_datestring(t.execution_date)
+                t.dag_id, t.task_id,
+                AirflowKubernetesScheduler._datetime_to_label_safe_datestring(t.execution_date)
             ))
-            pod_list = self.kube_client.list_namespaced_pod(self.kube_config.kube_namespace, **kwargs)
+            pod_list = self.kube_client.list_namespaced_pod(
+                self.kube_config.kube_namespace, **kwargs)
             if len(pod_list.items) == 0:
-                self.log.info("TaskInstance: {} found in queued state but was not launched, rescheduling".format(t))
+                self.log.info(
+                    "TaskInstance: {} found in queued state but was not launched, rescheduling"
+                    .format(t))
                 self._session.query(TaskInstance).filter(
                     TaskInstance.dag_id == t.dag_id,
                     TaskInstance.task_id == t.task_id,
@@ -416,7 +444,8 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
             self.log.info("Changing state of {}".format(results))
             self._change_state(key, state, pod_id)
 
-        KubeResourceVersion.checkpoint_resource_version(last_resource_version, session=self._session)
+        KubeResourceVersion.checkpoint_resource_version(
+            last_resource_version, session=self._session)
 
         if not self.task_queue.empty():
             key, command = self.task_queue.get()

--- a/airflow/contrib/kubernetes/kube_client.py
+++ b/airflow/contrib/kubernetes/kube_client.py
@@ -22,4 +22,5 @@ def get_kube_client(in_cluster=True):
         config.load_incluster_config()
         return client.CoreV1Api()
     else:
-        NotImplementedError("Running kubernetes jobs from not within the cluster is not supported at this time")
+        NotImplementedError(
+            "Running kubernetes jobs from not within the cluster is not supported at this time")

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/kubernetes_request_factory.py
@@ -18,18 +18,18 @@ import six
 
 class KubernetesRequestFactory():
     """
-        Create requests to be sent to kube API. Extend this class
-        to talk to kubernetes and generate your specific resources.
-        This is equivalent of generating yaml files that can be used
-        by `kubectl`
+    Create requests to be sent to kube API. Extend this class to talk to kubernetes and generate
+    your specific resources. This is equivalent of generating yaml files that can be used by
+    `kubectl`
     """
     __metaclass__ = ABCMeta
 
     @abstractmethod
     def create(self, pod):
         """
-            Creates the request for kubernetes API.
-            :param pod: The pod object
+        Creates the request for kubernetes API.
+
+        :param pod: The pod object
         """
         pass
 
@@ -80,7 +80,8 @@ class KubernetesRequestFactory():
     @staticmethod
     def attach_volume_mounts(pod, req):
         if len(pod.volume_mounts) > 0:
-            req['spec']['containers'][0]['volumeMounts'] = req['spec']['containers'][0].get('volumeMounts', [])
+            req['spec']['containers'][0]['volumeMounts'] = (
+                req['spec']['containers'][0].get('volumeMounts', []))
             req['spec']['containers'][0]['volumeMounts'].extend(pod.volume_mounts)
 
     @staticmethod

--- a/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
+++ b/airflow/contrib/kubernetes/kubernetes_request_factory/pod_request_factory.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 
 import yaml
-from airflow.contrib.kubernetes.kubernetes_request_factory.kubernetes_request_factory import KubernetesRequestFactory
+from airflow.contrib.kubernetes.kubernetes_request_factory.kubernetes_request_factory import (
+    KubernetesRequestFactory)
 from airflow.contrib.kubernetes.pod import Pod
 
 
 class SimplePodRequestFactory(KubernetesRequestFactory):
     """
-        Request generator for a simple pod.
+    Request generator for a simple pod.
     """
     _yaml = """apiVersion: v1
 kind: Pod

--- a/airflow/contrib/kubernetes/pod.py
+++ b/airflow/contrib/kubernetes/pod.py
@@ -15,18 +15,19 @@
 
 class Pod:
     """
-        Represents a kubernetes pod and manages execution of a single pod.
-        :param image: The docker image
-        :type image: str
-        :param env: A dict containing the environment variables
-        :type env: dict
-        :param cmds: The command to be run on the pod
-        :type cmd: list str
-        :param secrets: Secrets to be launched to the pod
-        :type secrets: list Secret
-        :param result: The result that will be returned to the operator after
-                       successful execution of the pod
-        :type result: any
+    Represents a kubernetes pod and manages execution of a single pod.
+
+    :param image: The docker image
+    :type image: str
+    :param env: A dict containing the environment variables
+    :type env: dict
+    :param cmds: The command to be run on the pod
+    :type cmd: list str
+    :param secrets: Secrets to be launched to the pod
+    :type secrets: list Secret
+    :param result: The result that will be returned to the operator after
+                   successful execution of the pod
+    :type result: any
     """
     pod_timeout = 3600
 

--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import enum
+
 import json
 
 from airflow.contrib.kubernetes.pod import Pod
@@ -26,7 +26,7 @@ from kubernetes.client.rest import ApiException
 from .kube_client import get_kube_client
 
 
-class PodStatus(enum.Enum):
+class PodStatus(object):
     PENDING = 'pending'
     RUNNING = 'running'
     FAILED = 'failed'
@@ -79,15 +79,15 @@ class PodLauncher(LoggingMixin):
         return self._client.read_namespaced_pod(pod.name, pod.namespace)
 
     def process_status(self, job_id, status):
-        if status == PodStatus.PENDING.value:
+        if status == PodStatus.PENDING:
             return State.QUEUED
-        elif status == PodStatus.FAILED.value:
+        elif status == PodStatus.FAILED:
             self.log.info("Event: {} Failed".format(job_id))
             return State.FAILED
-        elif status == PodStatus.SUCCEEDED.value:
+        elif status == PodStatus.SUCCEEDED:
             self.log.info("Event: {} Succeeded".format(job_id))
             return State.SUCCESS
-        elif status == PodStatus.RUNNING.value:
+        elif status == PodStatus.RUNNING:
             return State.RUNNING
         else:
             self.log.info("Event: Invalid state {} on job {}".format(status, job_id))

--- a/airflow/contrib/kubernetes/pod_launcher.py
+++ b/airflow/contrib/kubernetes/pod_launcher.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import enum
 import json
 
 from airflow.contrib.kubernetes.pod import Pod
-from airflow.contrib.kubernetes.kubernetes_request_factory.pod_request_factory import SimplePodRequestFactory
+from airflow.contrib.kubernetes.kubernetes_request_factory.pod_request_factory import (
+    SimplePodRequestFactory)
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 from kubernetes import watch
@@ -22,6 +24,13 @@ from kubernetes.client import V1Pod
 from kubernetes.client.rest import ApiException
 
 from .kube_client import get_kube_client
+
+
+class PodStatus(enum.Enum):
+    PENDING = 'pending'
+    RUNNING = 'running'
+    FAILED = 'failed'
+    SUCCEEDED = 'succeeded'
 
 
 class PodLauncher(LoggingMixin):
@@ -44,7 +53,7 @@ class PodLauncher(LoggingMixin):
     def run_pod(self, pod):
         # type: (Pod) -> State
         """
-            Launches the pod synchronously and waits for completion.
+        Launches the pod synchronously and waits for completion.
         """
         resp = self.run_pod_async(pod)
         final_status = self._monitor_pod(pod)
@@ -70,15 +79,15 @@ class PodLauncher(LoggingMixin):
         return self._client.read_namespaced_pod(pod.name, pod.namespace)
 
     def process_status(self, job_id, status):
-        if status == 'Pending':
+        if status == PodStatus.PENDING.value:
             return State.QUEUED
-        elif status == 'Failed':
+        elif status == PodStatus.FAILED.value:
             self.log.info("Event: {} Failed".format(job_id))
             return State.FAILED
-        elif status == 'Succeeded':
+        elif status == PodStatus.SUCCEEDED.value:
             self.log.info("Event: {} Succeeded".format(job_id))
             return State.SUCCESS
-        elif status == 'Running':
+        elif status == PodStatus.RUNNING.value:
             return State.RUNNING
         else:
             self.log.info("Event: Invalid state {} on job {}".format(status, job_id))

--- a/airflow/contrib/operators/kubernetes/pod_operator.py
+++ b/airflow/contrib/operators/kubernetes/pod_operator.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from airflow.exceptions import AirflowException
 from airflow.operators.python_operator import PythonOperator
 from airflow.utils.decorators import apply_defaults
@@ -24,16 +22,16 @@ from airflow.utils.state import State
 
 class PodOperator(PythonOperator):
     """
-        Executes a pod and waits for the job to finish.
-        :param dag_run_id: The unique run ID that would be attached to the pod as a label
-        :type dag_run_id: str
-        :param pod_factory: Reference to the function that creates the pod with format:
-                            function (OpContext) => Pod
-        :type pod_factory: callable
-        :param cache_output: If set to true, the output of the pod would be saved in a
-                            cache object using md5 hash of all the pod parameters
-                            and in case of success, the cached results will be returned
-                            on consecutive calls. Only use this
+    Executes a pod and waits for the job to finish.
+
+    :param dag_run_id: The unique run ID that would be attached to the pod as a label
+    :type dag_run_id: str
+    :param pod_factory: Reference to the function that creates the pod with format:
+        function (OpContext) => Pod
+    :type pod_factory: callable
+    :param cache_output: If set to true, the output of the pod would be saved in a
+        cache object using md5 hash of all the pod parameters and in case of success, the cached
+        results will be returned on consecutive calls. Only use this
     """
     # template_fields = tuple('dag_run_id')
     ui_color = '#8da7be'
@@ -56,7 +54,6 @@ class PodOperator(PythonOperator):
             provide_context=True,
             *args,
             **kwargs)
-        self.logger = logging.getLogger(self.__class__.__name__)
         self.pod = pod
         self.dag_run_id = dag_run_id
         self.pod_launcher = PodLauncher()
@@ -92,13 +89,12 @@ class PodOperator(PythonOperator):
 
     def on_pod_success(self, context):
         """
-            Called when pod is executed successfully.
-            
-            If you want to access return values for XCOM, place values
-            in accessible file system or DB and override this function.
-            
-            :return: Returns a custom return value for pod which will
-                     be stored in xcom
-                     
+        Called when pod is executed successfully.
+
+        If you want to access return values for XCOM, place values
+        in accessible file system or DB and override this function.
+
+        :return: Returns a custom return value for pod which will
+            be stored in xcom
         """
         return self._on_pod_success_func(context=context)

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -49,7 +49,7 @@ class BaseExecutor(LoggingMixin):
             self.log.info("Adding to queue: %s", command)
             self.queued_tasks[key] = (command, priority, queue, task_instance)
         else:
-            self.logger.info("could not queue task {}".format(key))
+            self.log.info("could not queue task {}".format(key))
 
     def queue_task_instance(
             self,

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -48,15 +48,16 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
 
     def _is_valid_name(self, name):
         regex = "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-        return len(name) <= 253 and \
-               all(ch.lower() == ch for ch in name) and \
-               re.match(regex, name)
+        return (
+            len(name) <= 253 and
+            all(ch.lower() == ch for ch in name) and
+            re.match(regex, name))
 
     @unittest.skipIf(AirflowKubernetesScheduler is None, 'kubernetes python package is not installed')
     def test_create_pod_id(self):
         for dag_id, task_id in self._cases():
             pod_name = AirflowKubernetesScheduler._create_pod_id(dag_id, task_id)
-            assert self._is_valid_name(pod_name)
+            self.assertTrue(self._is_valid_name(pod_name))
 
     @unittest.skipIf(AirflowKubernetesScheduler is None, "kubernetes python package is not installed")
     def test_execution_date_serialize_deserialize(self):
@@ -64,7 +65,7 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         serialized_datetime = AirflowKubernetesScheduler._datetime_to_label_safe_datestring(datetime_obj)
         new_datetime_obj = AirflowKubernetesScheduler._label_safe_datestring_to_datetime(serialized_datetime)
 
-        assert datetime_obj == new_datetime_obj
+        self.assertEquals(datetime_obj, new_datetime_obj)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@dimberman @grantnicholas @fenglu-g A handful of small cleanup items to address comments on the Airflow PR: https://github.com/apache/incubator-airflow/pull/2414

Basically: 
* Cleans log formatting
* Uses `self.log`, wraps at 100 lines
* Adds a `PodStatus` enum to replace string comparison for status

Note that I didn't handle changing/removing the Kubernetes Executor's `clear_not_launched_queued_tasks` because I thought we should likely verify that that functionality continues to work as expected if we follow that bit of advice.