### PR TITLE
[AIRFLOW-1755] URL prefix for flower and webservice

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1035,6 +1035,10 @@ def flower(args):
     if args.broker_api:
         api = '--broker_api=' + args.broker_api
 
+    url_prefix = ''
+    if args.url_prefix:
+        url_prefix = '--url-prefix=' + args.url_prefix
+
     flower_conf = ''
     if args.flower_conf:
         flower_conf = '--conf=' + args.flower_conf
@@ -1051,7 +1055,8 @@ def flower(args):
         )
 
         with ctx:
-            os.execvp("flower", ['flower', '-b', broka, address, port, api, flower_conf])
+            os.execvp("flower", ['flower', '-b', broka, address, port, api, flower_conf,
+                                 url_prefix])
 
         stdout.close()
         stderr.close()
@@ -1059,7 +1064,8 @@ def flower(args):
         signal.signal(signal.SIGINT, sigint_handler)
         signal.signal(signal.SIGTERM, sigint_handler)
 
-        os.execvp("flower", ['flower', '-b', broka, address, port, api, flower_conf])
+        os.execvp("flower", ['flower', '-b', broka, address, port, api, flower_conf,
+                             url_prefix])
 
 
 def kerberos(args):  # noqa
@@ -1298,6 +1304,10 @@ class CLIFactory(object):
             default=conf.get('webserver', 'WEB_SERVER_PORT'),
             type=int,
             help="The port on which to run the server"),
+        'url_prefix': Arg(
+            ('-u', "--url_prefix"),
+            default=conf.get('webserver', 'WEB_SERVER_URL_PREFIX'),
+            help="URL prefix for the server"),
         'ssl_cert': Arg(
             ("--ssl_cert",),
             default=conf.get('webserver', 'WEB_SERVER_SSL_CERT'),
@@ -1391,6 +1401,10 @@ class CLIFactory(object):
         'flower_conf': Arg(
             ("-fc", "--flower_conf"),
             help="Configuration file for flower"),
+        'flower_url_prefix': Arg(
+            ("-u", "--url_prefix"),
+            default=conf.get('celery', 'FLOWER_URL_PREFIX'),
+            help="URL prefix for Flower"),
         'task_params': Arg(
             ("-tp", "--task_params"),
             help="Sends a JSON params dict to the task"),
@@ -1517,7 +1531,7 @@ class CLIFactory(object):
             'func': webserver,
             'help': "Start a Airflow webserver instance",
             'args': ('port', 'workers', 'workerclass', 'worker_timeout', 'hostname',
-                     'pid', 'daemon', 'stdout', 'stderr', 'access_logfile',
+                     'url_prefix', 'pid', 'daemon', 'stdout', 'stderr', 'access_logfile',
                      'error_logfile', 'log_file', 'ssl_cert', 'ssl_key', 'debug'),
         }, {
             'func': resetdb,
@@ -1541,8 +1555,9 @@ class CLIFactory(object):
         }, {
             'func': flower,
             'help': "Start a Celery Flower",
-            'args': ('flower_hostname', 'flower_port', 'flower_conf', 'broker_api',
-                     'pid', 'daemon', 'stdout', 'stderr', 'log_file'),
+            'args': ('flower_hostname', 'flower_port', 'flower_conf',
+                     'flower_url_prefix', 'broker_api', 'pid', 'daemon',
+                     'stdout', 'stderr', 'log_file'),
         }, {
             'func': version,
             'help': "Show the version",

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -170,6 +170,9 @@ web_server_host = 0.0.0.0
 # The port on which to run the web server
 web_server_port = 8080
 
+# Root URL to use for the web server
+web_server_url_prefix =
+
 # Paths to the SSL certificate and key for the web server. When both are
 # provided SSL will be enabled. This does not change the web server port.
 web_server_ssl_cert =
@@ -292,6 +295,9 @@ flower_host = 0.0.0.0
 
 # This defines the port that Celery Flower runs on
 flower_port = 5555
+
+# The root URL for Flower
+flower_url_prefix =
 
 # Default queue that tasks get assigned to and that worker listen on.
 default_queue = default

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -436,3 +436,9 @@ as_dict.__doc__ = conf.as_dict.__doc__
 
 def set(section, option, value):  # noqa
     return conf.set(section, option, value)
+
+def get_url_prefix():
+    url_prefix = get('webserver', 'WEB_SERVER_URL_PREFIX')
+    if not url_prefix or url_prefix == '/':
+        url_prefix = ""
+    return url_prefix

--- a/airflow/contrib/plugins/metastore_browser/main.py
+++ b/airflow/contrib/plugins/metastore_browser/main.py
@@ -24,6 +24,7 @@ from airflow.hooks.mysql_hook import MySqlHook
 from airflow.hooks.presto_hook import PrestoHook
 from airflow.plugins_manager import AirflowPlugin
 from airflow.www import utils as wwwutils
+from airflow import configuration
 
 METASTORE_CONN_ID = 'metastore_default'
 METASTORE_MYSQL_CONN_ID = 'metastore_mysql'
@@ -54,7 +55,8 @@ class MetastoreBrowserView(BaseView, wwwutils.DataProfilingMixin):
         h = MySqlHook(METASTORE_MYSQL_CONN_ID)
         df = h.get_pandas_df(sql)
         df.db = (
-            '<a href="/admin/metastorebrowserview/db/?db=' +
+            '<a href=' + configuration.get_url_prefix() +
+            '"/admin/metastorebrowserview/db/?db=' +
             df.db + '">' + df.db + '</a>')
         table = df.to_html(
             classes="table table-striped table-bordered table-hover",
@@ -62,7 +64,8 @@ class MetastoreBrowserView(BaseView, wwwutils.DataProfilingMixin):
             escape=False,
             na_rep='',)
         return self.render(
-            "metastore_browser/dbs.html", table=table)
+            "metastore_browser/dbs.html", table=table,
+            url_prefix=configuration.get_url_prefix())
 
     @expose('/table/')
     def table(self):
@@ -71,7 +74,8 @@ class MetastoreBrowserView(BaseView, wwwutils.DataProfilingMixin):
         table = m.get_table(table_name)
         return self.render(
             "metastore_browser/table.html",
-            table=table, table_name=table_name, datetime=datetime, int=int)
+            table=table, table_name=table_name, datetime=datetime, int=int,
+            url_prefix=configuration.get_url_prefix())
 
     @expose('/db/')
     def db(self):
@@ -79,7 +83,8 @@ class MetastoreBrowserView(BaseView, wwwutils.DataProfilingMixin):
         m = HiveMetastoreHook(METASTORE_CONN_ID)
         tables = sorted(m.get_tables(db=db), key=lambda x: x.tableName)
         return self.render(
-            "metastore_browser/db.html", tables=tables, db=db)
+            "metastore_browser/db.html", tables=tables, db=db,
+            url_prefix=configuration.get_url_prefix())
 
     @wwwutils.gzipped
     @expose('/partitions/')

--- a/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/base.html
+++ b/airflow/contrib/plugins/metastore_browser/templates/metastore_browser/base.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,14 +31,14 @@
 {% block head %}
 {{ super() }}
 <link rel="stylesheet" type="text/css" href="{{ url_for("static", filename="dataTables.bootstrap.css") }}">
-<link href="/admin/static/vendor/select2/select2.css" rel="stylesheet">
+<link href="{{ url_for('static', filename='select2.css') }}" rel="stylesheet">
 {% endblock %}
 
 {% block tail %}
 {{ super() }}
 <script src="{{ url_for('static', filename='jquery.dataTables.min.js') }}"></script>
 <script src="{{ url_for('static', filename='dataTables.bootstrap.js') }}"></script>
-<script src="/admin/static/vendor/select2/select2.min.js" type="text/javascript"></script>
+<script src="{{ url_for('static', filename='select2.min.js') }}" type="text/javascript"></script>
 <script>
     // Filling up the table selector
     url = "{{ url_for('.objects') }}";

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -961,6 +961,7 @@ class TaskInstance(Base, LoggingMixin):
         iso = self.execution_date.isoformat()
         BASE_URL = configuration.get('webserver', 'BASE_URL')
         return BASE_URL + (
+            configuration.get_url_prefix() +
             "/admin/airflow/log"
             "?dag_id={self.dag_id}"
             "&task_id={self.task_id}"
@@ -972,6 +973,7 @@ class TaskInstance(Base, LoggingMixin):
         iso = self.execution_date.isoformat()
         BASE_URL = configuration.get('webserver', 'BASE_URL')
         return BASE_URL + (
+            configuration.get_url_prefix() +
             "/admin/airflow/action"
             "?action=success"
             "&task_id={self.task_id}"

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -68,7 +68,7 @@ ___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
  _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
  """
 
-BASE_LOG_URL = '/admin/airflow/log'
+BASE_LOG_URL = conf.get_url_prefix() + '/admin/airflow/log'
 LOGGING_LEVEL = logging.INFO
 
 # the prefix to append to gunicorn worker processes after init

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -30,13 +30,12 @@ from airflow.www.blueprints import routes
 from airflow.logging_config import configure_logging
 from airflow import jobs
 from airflow import settings
-from airflow import configuration
 
 
 def create_app(config=None, testing=False):
     app = Flask(__name__)
-    app.secret_key = configuration.get('webserver', 'SECRET_KEY')
-    app.config['LOGIN_DISABLED'] = not configuration.getboolean('webserver', 'AUTHENTICATE')
+    app.secret_key = conf.get('webserver', 'SECRET_KEY')
+    app.config['LOGIN_DISABLED'] = not conf.getboolean('webserver', 'AUTHENTICATE')
 
     csrf.init_app(app)
 
@@ -61,8 +60,10 @@ def create_app(config=None, testing=False):
 
         admin = Admin(
             app, name='Airflow',
-            static_url_path='/admin',
-            index_view=views.HomeView(endpoint='', url='/admin', name="DAGs"),
+            static_url_path=conf.get_url_prefix() + '/admin',
+            index_view=views.HomeView(endpoint='',
+                                      url=conf.get_url_prefix() + '/admin',
+                                      name="DAGs"),
             template_mode='bootstrap3',
         )
         av = admin.add_view

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -40,7 +40,7 @@
       {% endif %}
     </h3>
     <h4 class="pull-right">
-      <a class="label label-default" href="/admin/dagrun/?flt2_dag_id_equals={{ dag.dag_id }}">
+      <a class="label label-default" href="{{ url_for('dagrun.index_view') }}?flt2_dag_id_equals={{ dag.dag_id }}">
         schedule: {{ dag.schedule_interval }}
       </a>
     </h4>
@@ -334,7 +334,7 @@ function updateQueryStringParameter(uri, key, value) {
     });
 
     $("#btn_ti").click(function(){
-      url = "/admin/taskinstance/" +
+      url = "{{ url_for('taskinstance.index_view') }}" +
         "?flt1_dag_id_equals=" + dag_id +
         "&flt2_task_id_equals=" + task_id +
         "&sort=3&desc=1";
@@ -424,7 +424,7 @@ function updateQueryStringParameter(uri, key, value) {
     });
 
     $('#btn_edit_dagrun').click(function(){
-      window.location = '/admin/dagrun/edit/?id=' + id;
+      window.location = '{{ url_for("dagrun.edit_view") }}?id=' + id;
     });
 
   </script>

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,7 @@
       <a
           class="btn"
           style="border: none; background-color:{{ State.color(state)}}; color: {{ State.color_fg(state) }};"
-          href="/admin/taskinstance/?flt0_dag_id_equals={{ dag.dag_id }}&flt2_state_equals={{ state }}">
+          href="{{ url_for('taskinstance.index_view') }}?flt0_dag_id_equals={{ dag.dag_id }}&flt2_state_equals={{ state }}">
         {{ state }} <span class="badge">{{ count }}</span>
       </a>
       {% endfor %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -69,7 +69,7 @@
                 <!-- Column 1: Edit dag -->
                 <td class="text-center" style="width:10px;">
                     {% if dag_id in orm_dags %}
-                    <a href="/admin/dagmodel/edit/?id={{ dag_id }}" title="Info">
+                    <a href="{{ url_for('dagmodel.edit_view') }}?id={{ dag_id }}" title="Info">
                         <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
                     </a>
                     {% endif %}
@@ -100,7 +100,7 @@
                 <!-- Column 4: Dag Schedule -->
                 <td>
                     {% if dag_id in webserver_dags %}
-                    <a class="label label-default schedule {{ dag.dag_id }}" href="/admin/dagrun/?flt2_dag_id_equals={{ dag.dag_id }}">
+                    <a class="label label-default schedule {{ dag.dag_id }}" href="{{ url_for('dagrun.index_view') }}?flt2_dag_id_equals={{ dag.dag_id }}">
                         {{ dag.schedule_interval }}
                     </a>
                     {% endif %}
@@ -171,7 +171,7 @@
                 </a>
 
                 <!-- Logs -->
-                <a href="/admin/log/?sort=1&amp;desc=1&amp;flt1_dag_id_equals={{ dag.dag_id }}">
+                <a href="{{ url_for('log.index_view') }}?sort=1&amp;desc=1&amp;flt1_dag_id_equals={{ dag.dag_id }}">
                     <span class="glyphicon glyphicon-align-justify" aria-hidden="true" data-original-title="Logs"></span>
                 </a>
                 {% endif %}
@@ -200,9 +200,9 @@
 
     </div>
     {% if not hide_paused %}
-    <a href="/admin/?showPaused=False">Hide Paused DAGs</a>
+    <a href="{{ url_for('admin.index') }}?showPaused=False">Hide Paused DAGs</a>
     {% else %}
-    <a href="/admin/?showPaused=True">Show Paused DAGs</a>
+    <a href="{{ url_for('admin.index') }}?showPaused=True">Show Paused DAGs</a>
     {% endif %}
   </div>
 {% endblock %}
@@ -215,7 +215,7 @@
   <script src="{{ url_for('static', filename='bootstrap3-typeahead.min.js') }}"></script>
   <script>
 
-      const DAGS_INDEX = {{ url_for('admin.index') }}
+      const DAGS_INDEX = "{{ url_for('admin.index') }}"
       const ENTER_KEY_CODE = 13
 
       $('#dag_query').on('keypress', function (e) {
@@ -359,7 +359,7 @@
               })
               .on('click', function(d, i) {
                   if (d.count > 0)
-                    window.location = "/admin/dagrun/?flt1_dag_id_equals=" + d.dag_id + "&flt2_state_equals=" + d.state;
+                    window.location = "{{ url_for('dagrun.index_view') }}?flt1_dag_id_equals=" + d.dag_id + "&flt2_state_equals=" + d.state;
               })
               .on('mouseover', function(d, i) {
                 if (d.count > 0) {
@@ -438,7 +438,7 @@
               })
               .on('click', function(d, i) {
                   if (d.count > 0)
-                    window.location = "/admin/taskinstance/?flt1_dag_id_equals=" + d.dag_id + "&flt2_state_equals=" + d.state;
+                    window.location = "{{ url_for('taskinstance.index_view') }}?flt1_dag_id_equals=" + d.dag_id + "&flt2_state_equals=" + d.state;
               })
               .on('mouseover', function(d, i) {
                 if (d.count > 0) {

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -350,7 +350,7 @@
             $("#loading").css("display", "block");
             $("div#svg_container").css("opacity", "0.2");
             $.get(
-                "/admin/airflow/object/task_instances",
+                "{{ url_for('airflow.task_instances') }}",
                 {dag_id : "{{ dag.dag_id }}", execution_date : "{{ execution_date }}"})
             .done(
                 function(task_instances) {

--- a/airflow/www/templates/airflow/list_dags.html
+++ b/airflow/www/templates/airflow/list_dags.html
@@ -172,7 +172,7 @@
               <a href="{{ url_for("airflow.refresh", dag_id=row.dag_id) }}" title="Refresh">
                 <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
               </a>
-              <a href="/admin/log/?sort=1&desc=1&flt1_dag_id_equals={{ row.dag_id }}" title="Logs">
+              <a href="{{ url_for('log.index_view') }}?sort=1&desc=1&flt1_dag_id_equals={{ row.dag_id }}" title="Logs">
                  <i class="icon-list"></i>
                  <span class="glyphicon glyphicon-align-justify" aria-hidden="true"></span>
               </a>
@@ -276,7 +276,7 @@
               })
               .on('click', function(d, i) {
                   if (d.count > 0)
-                    window.location = "/admin/taskinstance/?flt1_dag_id_equals=" + d.dag_id + "&flt2_state_equals=" + d.state;
+                    window.location = "{{ url_for('taskinstance.index_view') }}?flt1_dag_id_equals=" + d.dag_id + "&flt2_state_equals=" + d.state;
               })
               .on('mouseover', function(d, i) {
                 if (d.count > 0) {

--- a/airflow/www/templates/airflow/nvd3.html
+++ b/airflow/www/templates/airflow/nvd3.html
@@ -1,13 +1,13 @@
-{# 
+{#
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,7 +71,7 @@ body {
   <div id="container">
     <h2>
         <span id="label">{{ label }}</span>
-        <a href="/admin/chart/edit/?id={{ chart.id }}" >
+        <a href="{{ url_for('chart.edit_view') }}?id={{ chart.id }}" >
             <span class="glyphicon glyphicon-edit" aria-hidden="true" ></span>
         </a>
     </h2>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -180,7 +180,7 @@ def label_link(v, c, m, p):
 
 
 def pool_link(v, c, m, p):
-    url = '/admin/taskinstance/?flt1_pool_equals=' + m.pool
+    url = conf.get_url_prefix() + '/admin/taskinstance/?flt1_pool_equals=' + m.pool
     return Markup("<a href='{url}'>{m.pool}</a>".format(**locals()))
 
 
@@ -243,6 +243,7 @@ def data_profiling_required(f):
 
 def fused_slots(v, c, m, p):
     url = (
+        conf.get_url_prefix() +
         '/admin/taskinstance/' +
         '?flt1_pool_equals=' + m.pool +
         '&flt2_state_equals=running')
@@ -251,6 +252,7 @@ def fused_slots(v, c, m, p):
 
 def fqueued_slots(v, c, m, p):
     url = (
+        conf.get_url_prefix() +
         '/admin/taskinstance/' +
         '?flt1_pool_equals=' + m.pool +
         '&flt2_state_equals=queued&sort=10&desc=1')
@@ -458,7 +460,7 @@ class Airflow(BaseView):
                 "Not supported anymore as the license was incompatible, "
                 "sorry",
                 "danger")
-            redirect('/admin/chart/')
+            redirect(conf.get_url_prefix() + '/admin/chart/')
 
         sql = ""
         if chart.show_sql:
@@ -748,7 +750,7 @@ class Airflow(BaseView):
                 "Task [{}.{}] doesn't seem to exist"
                 " at the moment".format(dag_id, task_id),
                 "error")
-            return redirect('/admin/')
+            return redirect(conf.get_url_prefix() + '/admin/')
         task = copy.copy(dag.get_task(task_id))
         task.resolve_template_files()
         ti = TI(task=task, execution_date=dttm)
@@ -823,7 +825,7 @@ class Airflow(BaseView):
                 "Task [{}.{}] doesn't seem to exist"
                 " at the moment".format(dag_id, task_id),
                 "error")
-            return redirect('/admin/')
+            return redirect(conf.get_url_prefix() + '/admin/')
 
         session = Session()
         xcomlist = session.query(XCom).filter(
@@ -909,7 +911,7 @@ class Airflow(BaseView):
     @wwwutils.notify_owner
     def trigger(self):
         dag_id = request.args.get('dag_id')
-        origin = request.args.get('origin') or "/admin/"
+        origin = request.args.get('origin') or conf.get_url_prefix() + "/admin/"
         dag = dagbag.get_dag(dag_id)
 
         if not dag:
@@ -1270,7 +1272,7 @@ class Airflow(BaseView):
         dag = dagbag.get_dag(dag_id)
         if dag_id not in dagbag.dags:
             flash('DAG "{0}" seems to be missing.'.format(dag_id), "error")
-            return redirect('/admin/')
+            return redirect(conf.get_url_prefix() + '/admin/')
 
         root = request.args.get('root')
         if root:
@@ -1371,7 +1373,8 @@ class Airflow(BaseView):
             task_instances=json.dumps(task_instances, indent=2),
             tasks=json.dumps(tasks, indent=2),
             nodes=json.dumps(nodes, indent=2),
-            edges=json.dumps(edges, indent=2), )
+            edges=json.dumps(edges, indent=2),
+            url_prefix=conf.get_url_prefix())
 
     @expose('/duration')
     @login_required
@@ -1788,7 +1791,7 @@ class Airflow(BaseView):
             for k, v in d.items():
                 models.Variable.set(k, v, serialize_json=isinstance(v, dict))
             flash("{} variable(s) successfully updated.".format(len(d)))
-        return redirect('/admin/variable')
+        return redirect(conf.get_url_prefix() + '/admin/variable')
 
 
 class HomeView(AdminIndexView):


### PR DESCRIPTION
Hello

Here is my change regarding url prefix in webserver and flower. Patch is being integrated in the main project, I just propose it here in case of you wanted to try it out in your fork (I will maintain a version with both your changes + this url_prefix feature that is needed in our kube infrastructure)

---
Allows Airflow to support accessing easily the
web UI from an endpoint such as `/airflow`
and Flower with `/flower`.

Adds 2 options in airflow.cfg:
- web_server_url_prefix for the webservice
- flower_url_prefix for Flower

Allow mounting on any kind of HTTP endpoint,
not only FQDN.

Example in`airflow.cfg`:

    # Root URL to use for the web server
    web_server_url_prefix = /airflow
    ...
    # The root URL for Flower
    flower_url_prefix = /flower
